### PR TITLE
fix: changed the time zone for Launch details

### DIFF
--- a/src/util/format-date.ts
+++ b/src/util/format-date.ts
@@ -9,7 +9,8 @@ export function formatDate(timestamp: string) {
         weekday: 'long',
         year: 'numeric',
         month: 'long',
-        day: 'numeric'
+        day: 'numeric',
+        timeZone: 'America/Los_Angeles'
     }).format(new Date(timestamp))
 }
 
@@ -20,6 +21,7 @@ export function formatDateTime(timestamp: string) {
         day: 'numeric',
         hour: 'numeric',
         minute: 'numeric',
-        timeZoneName: 'short'
+        timeZoneName: 'short',
+        timeZone: 'America/Los_Angeles'
     }).format(new Date(timestamp))
 }


### PR DESCRIPTION
This PR changes the timezone for the data launch in the Launch Details. 
As required, users should see the launch time displayed in the launch site's local time zone, as "November 21, 2020, 9:17 AM".

Acc. criteria: Instead of "November 21, 2020, 6:17 PM" users see "November 21, 2020, 9:17 AM".